### PR TITLE
Improve naming of the split files and add script to reassemble

### DIFF
--- a/src/main/java/org/overbaard/ci/multi/repo/generator/GitHubActionGenerator.java
+++ b/src/main/java/org/overbaard/ci/multi/repo/generator/GitHubActionGenerator.java
@@ -323,7 +323,7 @@ public class GitHubActionGenerator {
                         .setVersion(context.getJavaVersion())
                         .build());
 
-        if (component.getDependencies().size() > 0) {
+        if (needs.size() > 0) {
             // Get the maven artifact backups
             steps.add(
                     new GitCommandBuilder()

--- a/src/main/java/org/overbaard/ci/multi/repo/log/copy/CopyLogArtifacts.java
+++ b/src/main/java/org/overbaard/ci/multi/repo/log/copy/CopyLogArtifacts.java
@@ -42,7 +42,7 @@ public class CopyLogArtifacts {
     }
 
     private void copyArtifacts() throws Exception {
-        Files.walkFileTree(inputPath, new SimpleFileVisitor<Path>() {
+        Files.walkFileTree(inputPath.toAbsolutePath(), new SimpleFileVisitor<Path>() {
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                 String fileName = file.getFileName().toString();

--- a/src/main/java/org/overbaard/ci/multi/repo/maven/backup/BackupMavenArtifacts.java
+++ b/src/main/java/org/overbaard/ci/multi/repo/maven/backup/BackupMavenArtifacts.java
@@ -51,15 +51,15 @@ public class BackupMavenArtifacts {
             throw new IllegalStateException("Need the following three args: <root pom path> <maven repo root> <backupLocation>");
         }
 
-        Path rootPom = Paths.get(args[0]);
+        Path rootPom = Paths.get(args[0]).toAbsolutePath();
         if (!Files.exists(rootPom)) {
             throw new IllegalStateException("Root pom path does not exist: " + rootPom);
         }
-        Path mavenRepo = Paths.get(args[1]);
+        Path mavenRepo = Paths.get(args[1]).toAbsolutePath();
         if (!Files.exists(mavenRepo)) {
             throw new IllegalStateException("Maven repo does not exist: " + rootPom);
         }
-        Path backupLocation = Paths.get(args[2]);
+        Path backupLocation = Paths.get(args[2]).toAbsolutePath();
 
         BackupMavenArtifacts grabber = new BackupMavenArtifacts(rootPom, mavenRepo, backupLocation);
         grabber.recordModules(rootPom);

--- a/src/main/java/org/overbaard/ci/multi/repo/maven/backup/CopyDirectoryVisitor.java
+++ b/src/main/java/org/overbaard/ci/multi/repo/maven/backup/CopyDirectoryVisitor.java
@@ -1,22 +1,20 @@
 package org.overbaard.ci.multi.repo.maven.backup;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.io.Writer;
 import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.ArrayList;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.List;
-import java.util.UUID;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -28,8 +26,7 @@ public class CopyDirectoryVisitor extends SimpleFileVisitor<Path> {
     // GitHub's max file size is 100Mb. Set it to 90 just to have some leeway
     private static final long MAX_SIZE_BYTES = 90 * 1024 * 1024;
 
-    private static final String SPLIT_FILE_SUFFIX = ".splitfile";
-    private static final String SPLIT_FILE_PREFIX = SPLIT_FILE_SUFFIX + "-";
+    private static final String SPLIT_FILE_DIRECTORY_SUFFIX = ".split.file.dir";
 
     private final LargeFileAction largeFileAction;
     private final Path sourceDir;
@@ -41,8 +38,8 @@ public class CopyDirectoryVisitor extends SimpleFileVisitor<Path> {
 
     public CopyDirectoryVisitor(LargeFileAction largeFileAction, Path sourceDir, Path targetDir) {
         this.largeFileAction = largeFileAction;
-        this.sourceDir = sourceDir;
-        this.targetDir = targetDir;
+        this.sourceDir = sourceDir.toAbsolutePath();
+        this.targetDir = targetDir.toAbsolutePath();
     }
 
     @Override
@@ -57,8 +54,13 @@ public class CopyDirectoryVisitor extends SimpleFileVisitor<Path> {
     public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
         Path relative = sourceDir.relativize(file);
         Path target = targetDir.resolve(relative);
+
         System.out.println("Copying " + file + " to " + target);
+        if (Files.exists(target)) {
+            Files.delete(target);
+        }
         Files.copy(file, target);
+
         return FileVisitResult.CONTINUE;
     }
 
@@ -69,13 +71,18 @@ public class CopyDirectoryVisitor extends SimpleFileVisitor<Path> {
             Path relative = sourceDir.relativize(dir);
             Path target = targetDir.resolve(relative);
 
+            if (largeFileAction == LargeFileAction.MERGE) {
+                if (dir.getFileName().toString().endsWith(SPLIT_FILE_DIRECTORY_SUFFIX)) {
+                    mergeFiles(target);
+                    return FileVisitResult.SKIP_SUBTREE;
+                }
+            }
+
             try (Stream<Path> stream = Files.list(target)) {
                 List<Path> list = stream.collect(Collectors.toList());
                 for (Path f : list) {
                     if (largeFileAction == LargeFileAction.SPLIT) {
                         splitFile(f);
-                    } else if (largeFileAction == LargeFileAction.MERGE) {
-                        mergeFile(f);
                     }
                 }
             }
@@ -83,43 +90,33 @@ public class CopyDirectoryVisitor extends SimpleFileVisitor<Path> {
         return super.postVisitDirectory(dir, exc);
     }
 
-    private void mergeFile(Path file) throws IOException {
-        String filename = file.getFileName().toString();
-        if (filename.startsWith(SPLIT_FILE_PREFIX) && filename.endsWith(SPLIT_FILE_SUFFIX)) {
-            Path mergedFile;
-            List<Path> partNames = new ArrayList<>();
+    private void mergeFiles(Path splitDir) throws IOException {
+        String baseFileName = getFileNameFromSplitDirName(splitDir);
+        Path mergedTargetFile = splitDir.getParent().resolve(baseFileName);
+        System.out.println("Merging split dir " + splitDir + " to " + mergedTargetFile);
 
-            try (BufferedReader reader = new BufferedReader(new FileReader(file.toFile()))) {
-                String line = reader.readLine();
-                mergedFile = file.getParent().resolve(line);
-                line = reader.readLine();
+        try (RandomAccessFile toFile = new RandomAccessFile(mergedTargetFile.toFile(), "rw");
+                FileChannel toChannel = toFile.getChannel()) {
 
-                while (line != null) {
-                    partNames.add(file.getParent().resolve(line));
-                    line = reader.readLine();
+            int position = 0;
+
+            for (int index = 0 ; ; index++) {
+                Path path = splitDir.resolve(createFileNameForIndex(index));
+                if (!Files.exists(path)) {
+                    break;
+                }
+
+                try (RandomAccessFile part = new RandomAccessFile(path.toFile(), "r");
+                        FileChannel fromChannel = part.getChannel()) {
+                    long size = Files.size(path);
+                    toChannel.transferFrom(fromChannel, position, size);
+                    Files.delete(path);
+                    position += size;
                 }
             }
 
-            try (RandomAccessFile toFile = new RandomAccessFile(mergedFile.toFile(), "rw");
-                    FileChannel toChannel = toFile.getChannel()) {
-
-                int position = 0;
-
-                for (Path path : partNames) {
-                    try (RandomAccessFile part = new RandomAccessFile(path.toFile(), "r");
-                            FileChannel fromChannel = part.getChannel()) {
-                        long size = Files.size(path);
-                        toChannel.transferFrom(fromChannel, position, size);
-                        position += size;
-                    }
-                }
-            }
-            Files.delete(file);
-            for (Path path : partNames) {
-                Files.delete(path);
-            }
+            Files.walkFileTree(splitDir, new DeleteFilesVisitor());
         }
-
     }
 
     private void splitFile(Path file) throws IOException {
@@ -129,31 +126,26 @@ public class CopyDirectoryVisitor extends SimpleFileVisitor<Path> {
             long numSplits = sourceSize / bytesPerSplit;
             long remainingBytes = sourceSize % bytesPerSplit;
 
-            List<Path> partFiles = new ArrayList<>();
+            Path splitDir = file.getParent().resolve(file.getFileName().toString() + SPLIT_FILE_DIRECTORY_SUFFIX);
+            if (Files.exists(splitDir)) {
+                Files.walkFileTree(splitDir.toAbsolutePath(), new DeleteFilesVisitor());
+            }
+            Files.createDirectories(splitDir);
+            createReassembleScript(splitDir);
 
             try (RandomAccessFile sourceFile = new RandomAccessFile(file.toFile(), "r");
                     FileChannel sourceChannel = sourceFile.getChannel()) {
 
+
                 int position = 0;
+                long sourcePosition = 0;
                 for (; position < numSplits; position++) {
-                    Path part = writePartToFile(file, bytesPerSplit, position * bytesPerSplit, sourceChannel, partFiles);
-                    partFiles.add(part);
+                    writePartToFile(splitDir, bytesPerSplit, position, sourceChannel, sourcePosition);
+                    sourcePosition += bytesPerSplit;
                 }
 
                 if (remainingBytes > 0) {
-                    Path part = writePartToFile(file, remainingBytes, position * bytesPerSplit, sourceChannel, partFiles);
-                    partFiles.add(part);
-                }
-            }
-
-            String markerFileName = SPLIT_FILE_PREFIX + file.getFileName().toString() + SPLIT_FILE_SUFFIX;
-            Path markerPath = file.getParent().resolve(markerFileName);
-            try (Writer writer = new BufferedWriter(new FileWriter(markerPath.toFile()))) {
-                writer.write(file.getFileName().toString());
-                writer.write("\n");
-                for (Path path : partFiles) {
-                    writer.write(path.getFileName().toString());
-                    writer.write("\n");
+                    writePartToFile(splitDir, remainingBytes, position, sourceChannel, sourcePosition);
                 }
             }
 
@@ -161,16 +153,69 @@ public class CopyDirectoryVisitor extends SimpleFileVisitor<Path> {
         }
     }
 
-    private Path writePartToFile(Path file, long byteSize, long position, FileChannel sourceChannel, List<Path> partFiles) throws IOException {
-        Path fileName = Paths.get(file.toString() + "-" + UUID.randomUUID());
+    private Path writePartToFile(Path splitDir, long byteSize, int index, FileChannel sourceChannel, long sourcePosition) throws IOException {
+        Path fileName = splitDir.resolve(createFileNameForIndex(index));
         try (RandomAccessFile toFile = new RandomAccessFile(fileName.toFile(), "rw");
              FileChannel toChannel = toFile.getChannel()) {
 
-            sourceChannel.position(position);
+            sourceChannel.position(sourcePosition);
             toChannel.transferFrom(sourceChannel, 0, byteSize);
         }
         return fileName;
     }
+
+    private String createFileNameForIndex(int i) {
+        // If we change the length from 2 digits we also need to change the reassemble script
+        StringBuilder sb = new StringBuilder("xx.");
+        if (i < 10) {
+            sb.append("0");
+        }
+        if (i >= 100) {
+            // Very unlikely so I am not going to try to guard against it here
+            // (9GB should be more than enough, considering the size of the VMs)
+            throw new IllegalStateException("File is way too large!");
+        }
+        sb.append(i);
+        return sb.toString();
+    }
+
+    private void createReassembleScript(Path dir) throws IOException {
+        Path reassembleInstructions = dir.resolve("reassemble.sh");
+        StringBuilder sb = new StringBuilder();
+        sb.append("#!/bin/sh");
+        sb.append("# The file has been split due to its large size. Run this script to reassemble it.\n");
+        // Suffix length set by the format method is 2
+        sb.append("WORKING_DIR=$(dirname $0)\n");
+        sb.append("cat ${WORKING_DIR}/xx.?? > ${WORKING_DIR}/" + getFileNameFromSplitDirName(dir) + "\n");
+        sb.append("echo Reassembled ${WORKING_DIR}/" + getFileNameFromSplitDirName(dir) + "\n");
+        Files.createFile(reassembleInstructions);
+        Files.write(reassembleInstructions, sb.toString().getBytes(StandardCharsets.UTF_8), StandardOpenOption.WRITE);
+
+        String perm = "rwxr-xr-x";
+        Set<PosixFilePermission> permissions = PosixFilePermissions.fromString(perm);
+        Files.setPosixFilePermissions(reassembleInstructions, permissions);
+    }
+
+    private String getFileNameFromSplitDirName(Path splitDir) {
+        String filename = splitDir.getFileName().toString();
+        String baseFileName = filename.substring(0, filename.indexOf(SPLIT_FILE_DIRECTORY_SUFFIX));
+        return baseFileName;
+    }
+
+    private static class DeleteFilesVisitor extends SimpleFileVisitor<Path> {
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+            Files.delete(file);
+            return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+            Files.delete(dir);
+            return FileVisitResult.CONTINUE;
+        }
+    }
+
 
     enum LargeFileAction {
         NONE,

--- a/src/main/java/org/overbaard/ci/multi/repo/maven/backup/OverlayBackedUpMavenArtifacts.java
+++ b/src/main/java/org/overbaard/ci/multi/repo/maven/backup/OverlayBackedUpMavenArtifacts.java
@@ -24,8 +24,8 @@ public class OverlayBackedUpMavenArtifacts {
     private final Path backupsFolder;
 
     public OverlayBackedUpMavenArtifacts(Path mavenRepoRoot, Path backupsFolder) {
-        this.mavenRepoRoot = mavenRepoRoot;
-        this.backupsFolder = backupsFolder;
+        this.mavenRepoRoot = mavenRepoRoot.toAbsolutePath();
+        this.backupsFolder = backupsFolder.toAbsolutePath();
     }
 
     static void overlay(String[] args) throws Exception {
@@ -77,6 +77,9 @@ public class OverlayBackedUpMavenArtifacts {
         });
 
         for (Path repoDir : deletePaths) {
+            if (!Files.exists(repoDir)) {
+                break;
+            }
             Files.walkFileTree(repoDir, new SimpleFileVisitor<Path>(){
                 @Override
                 public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {


### PR DESCRIPTION
Ensure using absolute paths as Path.relativize() doesn't work well when
mixing absolute and relative paths.